### PR TITLE
Fix M5Cardputer boot loop and add M3U support

### DIFF
--- a/M5Cardputer_WebRadio_NL/CardWifiSetup.h
+++ b/M5Cardputer_WebRadio_NL/CardWifiSetup.h
@@ -139,7 +139,15 @@ void connectToWiFi() {
     } else {      
         M5Cardputer.Display.clear();
         M5Cardputer.Display.drawString("Finding WiFi", 1, 1);
-        CFG_WIFI_SSID = scanAndDisplayNetworks();
+
+        while (1) {
+            CFG_WIFI_SSID = scanAndDisplayNetworks();
+            if (CFG_WIFI_SSID.length() > 0) break;
+            M5Cardputer.Display.clear();
+            M5Cardputer.Display.drawString("No Networks. Rescanning...", 1, 20);
+            delay(1000);
+        }
+
         M5Cardputer.Display.clear();
         M5Cardputer.Display.drawString("SSID: " + CFG_WIFI_SSID, 1, 20);
         M5Cardputer.Display.drawString("Password:", 1, 38);

--- a/M5Cardputer_WebRadio_NL/M5Cardputer_WebRadio.ino
+++ b/M5Cardputer_WebRadio_NL/M5Cardputer_WebRadio.ino
@@ -19,6 +19,7 @@
 #include <M5Cardputer.h>
 #include <M5Unified.h>
 #include <Preferences.h>
+#include <HTTPClient.h>
 #include "CardWifiSetup.h"
 
 #include <AudioOutput.h>
@@ -231,10 +232,34 @@ public:
   }
 };
 
-static constexpr const int preallocateBufferSize = 128 * 1024;
+static constexpr const int preallocateBufferSize = 16 * 1024;
 static constexpr const int preallocateCodecSize = 85332; // MP3 and AAC+SBR codec max mem needed
 static void* preallocateBuffer = nullptr;
 static void* preallocateCodec = nullptr;
+
+String getDirectUrl(String url) {
+  if (url.endsWith(".m3u") || url.endsWith(".pls")) {
+     HTTPClient http;
+     http.begin(url);
+     int httpCode = http.GET();
+     if (httpCode == HTTP_CODE_OK) {
+        String payload = http.getString();
+        // Simple parser: look for http(s)://
+        int httpIndex = payload.indexOf("http");
+        if (httpIndex != -1) {
+           int endIndex = payload.indexOf('\n', httpIndex);
+           if (endIndex == -1) endIndex = payload.indexOf('\r', httpIndex);
+           if (endIndex == -1) endIndex = payload.length();
+           String newUrl = payload.substring(httpIndex, endIndex);
+           newUrl.trim();
+           return newUrl;
+        }
+     }
+     http.end();
+  }
+  return url;
+}
+
 static constexpr size_t WAVE_SIZE = 320;
 static AudioOutputM5Speaker out(&M5Cardputer.Speaker, m5spk_virtual_channel);
 static AudioGenerator *decoder = nullptr;
@@ -305,7 +330,8 @@ static void decodeTask(void*)
       meta_text[0] = station_list[index][0];
       stream_title[0] = 0;
       meta_mod_bits = 3;
-      file = new AudioFileSourceICYStream(station_list[index][1]);
+      String directUrl = getDirectUrl(station_list[index][1]);
+      file = new AudioFileSourceICYStream(directUrl.c_str());
       file->RegisterMetadataCB(MDCallback, (void*)"ICY");
       buff = new AudioFileSourceBuffer(file, preallocateBuffer, preallocateBufferSize);
       //decoder = isAAC ? (AudioGenerator*) new AudioGeneratorAAC(preallocateCodec, preallocateCodecSize) : (AudioGenerator*) new AudioGeneratorMP3(preallocateCodec, preallocateCodecSize);
@@ -616,6 +642,14 @@ void setup(void)
 
   preallocateBuffer = malloc(preallocateBufferSize);
   preallocateCodec = malloc(preallocateCodecSize);
+
+  if (!preallocateBuffer || !preallocateCodec) {
+    M5Cardputer.Display.fillScreen(TFT_RED);
+    M5Cardputer.Display.setCursor(0, 0);
+    M5Cardputer.Display.setTextSize(2);
+    M5Cardputer.Display.println("Memory Alloc Failed!");
+    while(1) delay(100);
+  }
 
   { /// custom setting
     auto spk_cfg = M5Cardputer.Speaker.config();


### PR DESCRIPTION
This PR fixes the boot failure on M5Stack Cardputer by reducing the preallocated audio buffer size from 128KB to 16KB, as the M5StampS3 lacks PSRAM. It also implements a `getDirectUrl` function to parse M3U and PLS playlists, allowing the radio to play stations that provide playlist files instead of direct streams. Additionally, it improves the WiFi setup robustness by retrying scans if no networks are found.

---
*PR created automatically by Jules for task [5969147226805486522](https://jules.google.com/task/5969147226805486522) started by @jayis1*